### PR TITLE
Expanding GWT integration for convenience & some javadoc clean up

### DIFF
--- a/hexa.binding.gwt/pom.xml
+++ b/hexa.binding.gwt/pom.xml
@@ -49,6 +49,11 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/Binder.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/Binder.java
@@ -1,48 +1,48 @@
 package fr.lteconsulting.hexa.databinding.gwt;
 
 import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.ListBox;
 
 import fr.lteconsulting.hexa.classinfo.gwt.ClazzBundle;
-import fr.lteconsulting.hexa.databinding.DataBinding;
 import fr.lteconsulting.hexa.databinding.propertyadapters.CompositePropertyAdapter;
 import fr.lteconsulting.hexa.databinding.propertyadapters.ObjectAsValuePropertyAdapter;
 import fr.lteconsulting.hexa.databinding.propertyadapters.PropertyAdapter;
+import fr.lteconsulting.hexa.databinding.propertyadapters.gwt.ListBoxPropertyAdapter;
 import fr.lteconsulting.hexa.databinding.propertyadapters.gwt.WidgetPropertyAdapter;
-
 
 /**
  * Binder is a class providing a fluent api access to DataBinding.
- * 
- * By default the data binding is : - in TwoWays mode, - without data converter,
- * - direct activation, - not logged.
- * 
+ * <br/>
+ * By default the data binding is:
+ * <ul>
+ * 	<li>in TwoWays mode,</li>
+ * 	<li>without data converter,</li>
+ * 	<li>direct activation, - not logged.</li>
+ * </ul>
  * One can create and activate data binding in one line like this :
+ * <pre>
+ * // selectedPerson to person form
+ * Binder.bind(personListBox, "selectedPerson").mode(Mode.OneWay).log("PERSONFORM").to(personForm, "person");
  * 
- * // selectedPerson to personne form Bind( personListWidget, "selectedPersonne"
- * ).Mode( Mode.OneWay ).Log("PERSONNEFORM").To( personneForm, "personne" );
+ * // selected person's category to category form
+ * Binder.bind(personListBox, "selectedPerson.category").mode(Mode.OneWay).to(categoryForm, "$DTOMap");
  * 
- * // selected person's category to category form Bind( personListWidget,
- * "selectedPersonne.category" ).Mode( Mode.OneWay ).To( categoryForm, "$DTOMap"
- * );
+ * // map selectedPerson to a person form
+ * Binder.bind(personListWidget, "selectedPerson").mapTo(personForm);
  * 
- * // map selectedPerson to a personne form Bind( personListWidget,
- * "selectedPersonne" ).MapTo( personneForm );
- * 
- * // selected person's description to Window's title Bind( personListWidget,
- * "selectedPersonne.description" ).Mode( Mode.OneWay ).To( new
- * WriteOnlyPropertyAdapter()
- * 
+ * // selected person's description to Window's title
+ * Binder.bind(personListWidget, "selectedPerson.description").mode(Mode.OneWay).to(new WriteOnlyPropertyAdapter())
+ * </pre>
  * The second parameter of the Bind and To methods, which is a String, is the
  * path to the desired property. It is '.' separated, so you can compose like
  * this : "person.category.creationDate" and the binding tool will automatically
  * follow the property's value.
- * 
+ * <br/><br/>
  * In order to support the data binding engine, one has also to declare a
  * {@link ClazzBundle} interface to process type information of the data-bounded
  * classes. Check the samples for further details.
  * 
  * @author Arnaud Tournier
- *
  */
 public class Binder
 {
@@ -76,7 +76,6 @@ public class Binder
 	 * possibilities.
 	 * 
 	 * @param source
-	 * @param propertyName
 	 * @return The Binder to continue specifying the data binding
 	 */
 	public static BindingCreation bind( PropertyAdapter source )
@@ -90,13 +89,27 @@ public class Binder
 	 * 
 	 * @param widget
 	 *            The HasValue widget, like a TextBox. The binding system will
-	 *            the use setValue, getValue and adValueChangeHandler methods to
+	 *            the use setValue, getValue and addValueChangeHandler methods to
 	 *            set, get and get change notifications on the widget.
 	 * @return The Binder to continue specifying the data binding
 	 */
 	public static BindingCreation bind( HasValue<?> widget )
 	{
 		return bind( new WidgetPropertyAdapter( widget ) );
+	}
+
+	/**
+	 * First step, accepts a data binding source definition and creates a binder
+	 *
+	 * @param listBox
+	 *            The ListBox widget, like a TextBox. The binding system will
+	 *            use the setValue, getValue and addChangeHandler methods to
+	 *            set, get and get change notifications on the widget.
+	 * @return The Binder to continue specifying the data binding
+	 */
+	public static BindingCreation bind( ListBox listBox )
+	{
+		return bind( new ListBoxPropertyAdapter( listBox ) );
 	}
 
 	/**
@@ -117,13 +130,9 @@ public class Binder
 	/**
 	 * Maps two objects together. All matching fields will then be two-way
 	 * data-bound.
-	 * 
-	 * @param source
-	 * @param destination
-	 * @return
 	 */
 	public static DataBinding map( Object source, Object destination )
 	{
-		return bindObject( source ).mapTo( destination );
+		return (DataBinding)bindObject(source).mapTo( destination );
 	}
 }

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
@@ -21,6 +21,8 @@ import fr.lteconsulting.hexa.databinding.propertyadapters.gwt.WidgetPropertyAdap
  */
 public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCreation
 {
+	protected boolean fDeferActivate;
+
 	public BindingCreation( PropertyAdapter source )
 	{
 		super(source);
@@ -66,10 +68,19 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 		super.log(prefix);
 		return this;
 	}
-	
-	@Override
-	public BindingCreation deferActivate() {
-		super.deferActivate();
+
+	/**
+	 * Second step, parameters.
+	 *
+	 * The created data binding will be activated at the next event loop. The
+	 * Scheduler.get().scheduleDeferred() method will be used.
+	 *
+	 * @return The Binder to continue specifying the data binding
+	 */
+	public BindingCreation deferActivate()
+	{
+		fDeferActivate = true;
+
 		return this;
 	}
 	
@@ -83,5 +94,32 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	public BindingCreation withConverter( Converter converter) {
 		super.withConverter(converter);
 		return this;
+	}
+
+	/**
+	 * Final step, defines the data binding destination and activates the
+	 * binding
+	 *
+	 * This method accepts any implementation of PropertyAdapter, especially
+	 * user ones so that is a good start to customize the data binding
+	 * possibilities
+	 *
+	 * @param destination
+	 *            The destination property adapter
+	 * @return The DataBinding object
+	 */
+	@Override
+	public DataBinding to( PropertyAdapter destination )
+	{
+		// create the binding according to the parameters
+		DataBinding binding = new DataBinding( source, destination, mode, converter, logPrefix );
+
+		// activate the binding : launch a value event
+		if( fDeferActivate )
+			binding.deferActivate();
+		else
+			binding.activate();
+
+		return binding;
 	}
 }

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
@@ -2,10 +2,11 @@ package fr.lteconsulting.hexa.databinding.gwt;
 
 import com.google.gwt.user.client.ui.HasValue;
 
+import com.google.gwt.user.client.ui.ListBox;
 import fr.lteconsulting.hexa.databinding.Converter;
-import fr.lteconsulting.hexa.databinding.DataBinding;
 import fr.lteconsulting.hexa.databinding.Mode;
 import fr.lteconsulting.hexa.databinding.propertyadapters.PropertyAdapter;
+import fr.lteconsulting.hexa.databinding.propertyadapters.gwt.ListBoxPropertyAdapter;
 import fr.lteconsulting.hexa.databinding.propertyadapters.gwt.WidgetPropertyAdapter;
 
 /**
@@ -27,11 +28,11 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	
 	/**
 	 * Final step, defines the data binding destination and activates the
-	 * binding
+	 * binding.
 	 * 
 	 * The object used as the binding's destination is a HasValue widget, like a
 	 * TextBox. The binding system will the use setValue, getValue and
-	 * adValueChangeHandler methods to set, get and get change notifications on
+	 * addValueChangeHandler methods to set, get and get change notifications on
 	 * the @param widget parameter.
 	 * 
 	 * @param widget
@@ -40,7 +41,24 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	 */
 	public DataBinding to( HasValue<?> widget )
 	{
-		return to( new WidgetPropertyAdapter( widget ) );
+		return (DataBinding)to(new WidgetPropertyAdapter(widget));
+	}
+
+	/**
+	 * Final step, defines the data binding destination and activates the
+	 * binding.
+	 *
+	 * The object used as the binding's destination is a ListBox widget.
+	 * The binding system will the use setValue, getValue and addChangeHandler
+	 * methods to set, get and get change notifications on the @param widget parameter.
+	 *
+	 * @param listBox
+	 *            The widget
+	 * @return The DataBinding object
+	 */
+	public DataBinding to( ListBox listBox )
+	{
+		return (DataBinding)to(new ListBoxPropertyAdapter(listBox));
 	}
 	
 	@Override
@@ -62,7 +80,7 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	}
 	
 	@Override
-	public fr.lteconsulting.hexa.databinding.BindingCreation withConverter( Converter converter) {
+	public BindingCreation withConverter( Converter converter) {
 		super.withConverter(converter);
 		return this;
 	}

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/BindingCreation.java
@@ -43,7 +43,7 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	 */
 	public DataBinding to( HasValue<?> widget )
 	{
-		return (DataBinding)to(new WidgetPropertyAdapter(widget));
+		return to(new WidgetPropertyAdapter(widget));
 	}
 
 	/**
@@ -60,7 +60,7 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 	 */
 	public DataBinding to( ListBox listBox )
 	{
-		return (DataBinding)to(new ListBoxPropertyAdapter(listBox));
+		return to(new ListBoxPropertyAdapter(listBox));
 	}
 	
 	@Override
@@ -96,18 +96,6 @@ public class BindingCreation extends fr.lteconsulting.hexa.databinding.BindingCr
 		return this;
 	}
 
-	/**
-	 * Final step, defines the data binding destination and activates the
-	 * binding
-	 *
-	 * This method accepts any implementation of PropertyAdapter, especially
-	 * user ones so that is a good start to customize the data binding
-	 * possibilities
-	 *
-	 * @param destination
-	 *            The destination property adapter
-	 * @return The DataBinding object
-	 */
 	@Override
 	public DataBinding to( PropertyAdapter destination )
 	{

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/DataBinding.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/DataBinding.java
@@ -12,11 +12,13 @@ import fr.lteconsulting.hexa.databinding.propertyadapters.PropertyAdapter;
  */
 public class DataBinding extends fr.lteconsulting.hexa.databinding.DataBinding {
 
-    public DataBinding(Object source, String sourceProperty, Object destination, String destinationProperty, Mode bindingMode) {
+    public DataBinding(Object source, String sourceProperty, Object destination,
+                       String destinationProperty, Mode bindingMode) {
         super(source, sourceProperty, destination, destinationProperty, bindingMode);
     }
 
-    public DataBinding(PropertyAdapter source, PropertyAdapter destination, Mode bindingMode, Converter converter, String logPrefix) {
+    public DataBinding(PropertyAdapter source, PropertyAdapter destination, Mode bindingMode,
+                       Converter converter, String logPrefix) {
         super(source, destination, bindingMode, converter, logPrefix);
     }
 

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/DataBinding.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/gwt/DataBinding.java
@@ -1,0 +1,52 @@
+package fr.lteconsulting.hexa.databinding.gwt;
+
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import fr.lteconsulting.hexa.databinding.Converter;
+import fr.lteconsulting.hexa.databinding.Mode;
+import fr.lteconsulting.hexa.databinding.propertyadapters.PropertyAdapter;
+
+/**
+ * DataBinding for GWT implementation.
+ * @author Ben Dol
+ */
+public class DataBinding extends fr.lteconsulting.hexa.databinding.DataBinding {
+
+    public DataBinding(Object source, String sourceProperty, Object destination, String destinationProperty, Mode bindingMode) {
+        super(source, sourceProperty, destination, destinationProperty, bindingMode);
+    }
+
+    public DataBinding(PropertyAdapter source, PropertyAdapter destination, Mode bindingMode, Converter converter, String logPrefix) {
+        super(source, destination, bindingMode, converter, logPrefix);
+    }
+
+    @Override
+    public DataBinding activate() {
+        return (DataBinding) super.activate();
+    }
+
+    @Override
+    public DataBinding suspend() {
+        return (DataBinding) super.suspend();
+    }
+
+    @Override
+    public void terminate() {
+        super.terminate();
+    }
+
+    /**
+     * Activates the data binding using the deferred scheduler.
+     * @see #activate()
+     */
+    public void deferActivate() {
+        log( "deferred activation..." );
+
+        Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+            @Override
+            public void execute() {
+                activate();
+            }
+        });
+    }
+}

--- a/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/propertyadapters/gwt/ListBoxPropertyAdapter.java
+++ b/hexa.binding.gwt/src/main/java/fr/lteconsulting/hexa/databinding/propertyadapters/gwt/ListBoxPropertyAdapter.java
@@ -1,0 +1,58 @@
+package fr.lteconsulting.hexa.databinding.propertyadapters.gwt;
+
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.ListBox;
+import fr.lteconsulting.hexa.client.tools.Action2;
+import fr.lteconsulting.hexa.databinding.propertyadapters.PropertyAdapter;
+
+/**
+ * A PropertyAdapter to bind a {@link ListBox}.<br/>
+ * 
+ * - When receiving an object, the adapter will set it as the selected object.<br/>
+ * - When the selected item changes, the binding system gets triggered.
+ * 
+ * @author Ben Dol
+ */
+public class ListBoxPropertyAdapter implements PropertyAdapter {
+	private ListBox listBox;
+
+	/**
+	 * Uses the given {@link ListBox} and acts as a binding property.
+	 * Used to bind the objects change value to another value.
+	 */
+	public ListBoxPropertyAdapter(ListBox listBox) {
+		this.listBox = listBox;
+	}
+
+	@Override
+	public void setValue(Object object) {
+		for(int i = 0; i < listBox.getItemCount(); i++) {
+			if (listBox.getValue(i).equals(object.toString())) {
+				listBox.setSelectedIndex(i);
+				return;
+			}
+		}
+	}
+
+	@Override
+	public Object getValue() {
+		return listBox.getSelectedValue();
+	}
+	
+	@Override
+	public void removePropertyChangedHandler(Object handlerRegistration) {
+		((HandlerRegistration)handlerRegistration).removeHandler();
+	}
+	
+	@Override
+	public Object registerPropertyChanged(final Action2<PropertyAdapter, Object> callback, final Object cookie) {
+		return listBox.addChangeHandler(new ChangeHandler() {
+			@Override
+			public void onChange(ChangeEvent event) {
+				callback.exec(ListBoxPropertyAdapter.this, cookie);
+			}
+		});
+	}
+}

--- a/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/BindingCreation.java
+++ b/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/BindingCreation.java
@@ -18,7 +18,6 @@ public class BindingCreation
 	protected final PropertyAdapter source;
 	protected Mode mode = Mode.TwoWay;
 	protected Converter converter;
-	protected boolean fDeferActivate;
 	protected String logPrefix;
 	
 	public BindingCreation( PropertyAdapter source )
@@ -62,28 +61,12 @@ public class BindingCreation
 	 * Defines a converter to be used by the data binding system when getting
 	 * and setting values.
 	 * 
-	 * @param mode
+	 * @param converter
 	 * @return The Binder to continue specifying the data binding
 	 */
 	public BindingCreation withConverter( Converter converter )
 	{
 		this.converter = converter;
-
-		return this;
-	}
-
-	/**
-	 * Second step, parameters.
-	 * 
-	 * The created data binding will be activated at the next event loop. The
-	 * Scheduler.get().scheduleDeferred() method will be used.
-	 * 
-	 * @param mode
-	 * @return The Binder to continue specifying the data binding
-	 */
-	public BindingCreation deferActivate()
-	{
-		fDeferActivate = true;
 
 		return this;
 	}
@@ -146,11 +129,8 @@ public class BindingCreation
 		// create the binding according to the parameters
 		DataBinding binding = new DataBinding( source, destination, mode, converter, logPrefix );
 
-		// activate the binding : launch a value event
-		if( fDeferActivate )
-			binding.deferActivate();
-		else
-			binding.activate();
+		// activate the binding
+		binding.activate();
 
 		return binding;
 	}

--- a/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/DataBinding.java
+++ b/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/DataBinding.java
@@ -89,24 +89,6 @@ public class DataBinding
 	}
 
 	/**
-	 * Switch to the deferred activation mode
-	 */
-	public void deferActivate()
-	{
-		log( "deferred activation..." );
-
-		// TODO : Make that platform independant
-//		Scheduler.get().scheduleDeferred( new ScheduledCommand()
-//		{
-//			@Override
-//			public void execute()
-//			{
-//				activate();
-//			}
-//		} );
-	}
-
-	/**
 	 * Terminates the Data Binding activation and cleans up all related
 	 * resources. You should call this method when you want to free the binding,
 	 * in order to lower memory usage.
@@ -128,7 +110,7 @@ public class DataBinding
 
 	}
 
-	private void log( String text )
+	protected void log( String text )
 	{
 		if( logPrefix == null )
 			return;

--- a/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/converters/EnumConverter.java
+++ b/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/converters/EnumConverter.java
@@ -1,0 +1,65 @@
+package fr.lteconsulting.hexa.databinding.converters;
+
+import fr.lteconsulting.hexa.databinding.Converter;
+
+/**
+ * Converter for enum types.
+ * @author Ben Dol
+ */
+public class EnumConverter implements Converter
+{
+
+    private Enum[] values;
+    private boolean toOrdinal;
+
+    /**
+     * Default constructor, will use the enums ordinal value by default.
+     * @see #EnumConverter(Enum[] values, boolean toOrdinal)
+     */
+    public EnumConverter(Enum[] values)
+    {
+        this(values, true);
+    }
+
+    /**
+     * Constructor to define whether or not the enum should be used as its
+     * ordinal value, otherwise it will simply call toString on the enum.
+     */
+    public EnumConverter(Enum[] values, boolean toOrdinal)
+    {
+        this.values = values;
+        this.toOrdinal = toOrdinal;
+    }
+
+    @Override
+    public Object convert(Object value)
+    {
+        if(toOrdinal)
+        {
+            for(int i = 0; i < values.length; ++i)
+            {
+                if(values[i].equals(value))
+                    return i;
+            }
+        }
+        return value.toString();
+    }
+
+    @Override
+    public Object convertBack(Object value)
+    {
+        Enum e = null;
+        try {
+            if (value instanceof Integer)
+                e = values[(Integer) value];
+            else if (value instanceof String)
+                e = values[Integer.parseInt((String)value)];
+        }
+        catch (Exception ex)
+        {
+            throw new IllegalArgumentException("Attempted to convert an " +
+                "enum using an invalid value: " + ex.getMessage());
+        }
+        return e;
+    }
+}

--- a/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/converters/EnumConverter.java
+++ b/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/converters/EnumConverter.java
@@ -6,38 +6,33 @@ import fr.lteconsulting.hexa.databinding.Converter;
  * Converter for enum types.
  * @author Ben Dol
  */
-public class EnumConverter implements Converter
-{
+public class EnumConverter implements Converter {
 
     private Enum[] values;
+
     private boolean toOrdinal;
 
     /**
-     * Default constructor, will use the enums ordinal value by default.
+     * Default constructor, won't use the enums ordinal value by default.
      * @see #EnumConverter(Enum[] values, boolean toOrdinal)
      */
-    public EnumConverter(Enum[] values)
-    {
-        this(values, true);
+    public EnumConverter(Enum[] values) {
+        this(values, false);
     }
 
     /**
      * Constructor to define whether or not the enum should be used as its
      * ordinal value, otherwise it will simply call toString on the enum.
      */
-    public EnumConverter(Enum[] values, boolean toOrdinal)
-    {
+    public EnumConverter(Enum[] values, boolean toOrdinal) {
         this.values = values;
         this.toOrdinal = toOrdinal;
     }
 
     @Override
-    public Object convert(Object value)
-    {
-        if(toOrdinal)
-        {
-            for(int i = 0; i < values.length; ++i)
-            {
+    public Object convert(Object value) {
+        if(toOrdinal) {
+            for(int i = 0; i < values.length; ++i) {
                 if(values[i].equals(value))
                     return i;
             }
@@ -46,19 +41,33 @@ public class EnumConverter implements Converter
     }
 
     @Override
-    public Object convertBack(Object value)
-    {
+    public Object convertBack(Object value) {
         Enum e = null;
         try {
-            if (value instanceof Integer)
+            if (value instanceof Integer) {
                 e = values[(Integer) value];
-            else if (value instanceof String)
-                e = values[Integer.parseInt((String)value)];
+            }
+            else if (value instanceof String) {
+                try {
+                    // Find by ordinal value first
+                    e = values[Integer.parseInt((String)value)];
+                }
+                catch(NumberFormatException | IndexOutOfBoundsException ex) {
+                    // Failed to find by ordinal value
+                    // Try find by enum name string
+                    for(Enum val : values) {
+                        if(val.name().equals(value)) {
+                            e = val;
+                            break;
+                        }
+                    }
+                    assert e != null;
+                }
+            }
         }
-        catch (Exception ex)
-        {
+        catch (Exception ex) {
             throw new IllegalArgumentException("Attempted to convert an " +
-                "enum using an invalid value: " + ex.getMessage());
+                "enum using an invalid value: ", ex);
         }
         return e;
     }

--- a/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/properties/PropertyValues.java
+++ b/hexa.binding/src/main/java/fr/lteconsulting/hexa/databinding/properties/PropertyValues.java
@@ -287,7 +287,9 @@ class PropertyValues {
 			return field.getValue(object);
 
 		// Maybe a dynamic property will be set later on
-		LOGGER.warning("DataBinding: Warning: assuming that the object would in the future have a dynamic property set / Maybe have an opt-in option on the Binding to clarify things");
+		LOGGER.warning("DataBinding: Warning: assuming that the object would " +
+			"in the future have a dynamic property set / Maybe have an opt-in " +
+			"option on the Binding to clarify things");
 
 		return null;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mavenVersion>3.0</mavenVersion>
         <gwt.version>[2.5.0,)</gwt.version>
+
+        <maven-source-plugin.version>2.3</maven-source-plugin.version>
     </properties>
     <distributionManagement>
         <snapshotRepository>
@@ -185,6 +187,20 @@
                             <phase>verify</phase>
                             <goals>
                                 <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>jar-no-fork</goal>
                             </goals>
                         </execution>
                     </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -191,20 +191,6 @@
                         </execution>
                     </executions>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>${maven-source-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>attach-sources</id>
-                            <phase>verify</phase>
-                            <goals>
-                                <goal>jar-no-fork</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
         <resources>


### PR DESCRIPTION
1. Added ListBoxPropertyAdapter to bind ListBox widgets easier (supporting multiple select list boxes).
2. Added an EnumConverter for processing Enum types.
3. Seperated DataBinding logic for GWT (deferActivate).
4. Fixed bug where withConverter would return a standard BindingCreation, rather than *.gwt.BindingCreation
5. Added `maven-source-plugin` to the hexa.binding.gwt POM to package sources by default.
6. Made Binder class javadoc more readable.

Simplifies ListBox binding for example:

``` java
Binder.bind(setting, "type")
      .withConverter(new EnumConverter(SettingType.values()))
      .to(typeBox);
```

or multiselect ListBox:

``` java
// types = List<String> types
Binder.bind(setting, "types").to(typeBox);
```

Will probably update this as I go or you can merge it and I can create more PR's as I update things for GWT. I intend to use this for one of my projects if its not too encumbering with the reflection data. Thanks for the cool project will help make it better for GWT users!
